### PR TITLE
fix php52 deployment permissions bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Some additional variables can be added to your hosts definition in the `servers.
 `env_symlinks` - see `deploy:symlink_envs` in `common-tasks.php`  
 `update_autoload_classmap` - see `deploy:update_autoload_classmap` in `common-tasks.php`
 
+## Development  
+
+Notes on developing this project.
+
+It's best to symlink this project from your global composer path. This way your edits can be tested right away.  
+
+This is how I used a symlink on my system:  
+```
+martin@lat3351:~/.config/composer/vendor/pointblue$ ln -sf /home/martin/Workspace/devops/devenv/deployer deployer
+```
+
+This allows the `require 'pointblue/deployer/common-tasks.php';` line in `deploy.php` to refer to the pointblue/deployer
+repo I cloned. Now my edits are under source control and can be tested lived.  
+
 
 ## Reference  
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Some additional variables can be added to your hosts definition in the `servers.
 
 Notes on developing this project.
 
+### Symlink to global composer path (optional)
+
 It's best to symlink this project from your global composer path. This way your edits can be tested right away.  
 
 This is how I used a symlink on my system:  
@@ -79,6 +81,18 @@ martin@lat3351:~/.config/composer/vendor/pointblue$ ln -sf /home/martin/Workspac
 
 This allows the `require 'pointblue/deployer/common-tasks.php';` line in `deploy.php` to refer to the pointblue/deployer
 repo I cloned. Now my edits are under source control and can be tested lived.  
+
+### Use debug tasks  
+
+You can run debug tasks from you machine to see how individual functions behave and drop break points.  
+
+  - From the command line, go to a locally cloned repo that uses common-tasks.php in it's deploy.php file
+  - Run `dep debug:say_hello prod` where `prod` is any target machine you can deploy to (from your current command line)
+  - You should be able to see 'hello, world!' printed in your console
+  - You should also be able to set a breakpoint on this line in PHPStorm
+  - Use this pattern to create more debug tasks
+  
+
 
 
 ## Reference  

--- a/common-tasks.php
+++ b/common-tasks.php
@@ -1149,6 +1149,10 @@ task('deploy:common_symlinks', function(){
 
 });
 
+task('debug:say_hello', function(){
+    writeln('hello, world!');
+});
+
 function has_deju_mapped_classes($mappedClasses)
 {
     for($i=0;$i<count($mappedClasses);$i++)
@@ -1163,6 +1167,12 @@ function has_deju_mapped_classes($mappedClasses)
     }
 
     return false;
+}
+
+function has_php52_host()
+{
+    $host = get('host');
+    //TODO: Find the substring 'php52' in the host; return true if found, otherwise false
 }
 
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a74d2e909648c026ba7137caaf47324c",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "ext-json": "*"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
This is the test from the most relevant commit:

---

with the addition of docker to our environment, we started getting permissions errors.
our deployment folder is shared between the host server and docker. we deploy code to
the host server and it's server from docker. when the folder is mounted the file
owner/groups are wrong (not set to www-data:www-data). if we ssh into the docker system
and change the owner/groups, the owner changes on the host machine to ubuntu, which
blocks the deployer user's access to correctly run it's deploy tasks.

all new behaviors only affect deployments that contain the string `php52` in the
`host` field of the `servers.yml`. Example: `dep deploy nonprod-php52`

this will:
  - change the owner of the host machine deployer folder to deployer:deployer
  before any other task
  - change to owner of the docker machine deployer folder to deployer:deployer near the
  end of all other tasks

to make this work:
  - the `deployer` user must be in the sudoer group: `sudo usermod -aG sudo deployer`
  - set permissions in `/etc/sudoers` to
  `deployer ALL=(ALL) NOPASSWD: /bin/chown, /usr/bin/docker`
  - deployer user must be added to ubuntu group: `sudo usermod -aG ubuntu deployer`